### PR TITLE
Add search analytics and reporting

### DIFF
--- a/Task 9,md
+++ b/Task 9,md
@@ -1,0 +1,22 @@
+# Task 9 - Search Analytics
+
+This task adds basic monitoring for search operations in the RAG system.
+
+## Implemented Features
+
+1. **SearchAnalytics class** (`src/trackrealties/analytics/search.py`)
+   - Stores search execution logs in memory.
+   - Records query text, chosen strategy, response time, and result count.
+   - Provides aggregation methods to build a simple performance report.
+2. **Integration with `EnhancedRAGPipeline`**
+   - Each search request now logs analytics data including strategy used and response time.
+3. **New API Endpoint** `/analytics/search-report`
+   - Returns aggregated metrics from `SearchAnalytics.generate_performance_report()`.
+
+## Usage
+
+1. Perform searches using the existing `/rag/search` or `/rag/query` endpoints.
+2. Retrieve analytics by calling `GET /analytics/search-report`.
+   The response summarizes strategy usage, recent queries, and failed searches.
+
+This functionality helps monitor search effectiveness and performance without requiring an external database.

--- a/rag_pipeline_integration.py
+++ b/rag_pipeline_integration.py
@@ -4,10 +4,12 @@ Replace existing search.py implementation with optimized routing
 """
 
 import logging
+from datetime import datetime
 from typing import List, Dict, Any, Optional
 from src.trackrealties.core.graph import graph_manager
 from src.trackrealties.core.database import db_pool
 from src.trackrealties.models.search import SearchResult
+from src.trackrealties.analytics.search import search_analytics, SearchAnalytics
 from smart_search_implementation import (
     SmartSearchRouter,
     FixedGraphSearch,
@@ -487,11 +489,13 @@ class EnhancedRAGPipeline:
     Enhanced RAG pipeline with smart search routing
     """
     
-    def __init__(self):
+    def __init__(self, analytics: SearchAnalytics | None = None):
         self.smart_router = SmartSearchRouter()
         self.vector_search = OptimizedVectorSearch()
         self.graph_search = OptimizedGraphSearch()
         self.hybrid_search = OptimizedHybridSearch()
+
+        self.analytics = analytics or search_analytics
         
         # Set search engines in router
         self.smart_router.vector_search = self.vector_search
@@ -517,17 +521,29 @@ class EnhancedRAGPipeline:
             await self.initialize()
         
         try:
+            start_time = datetime.utcnow()
+
             # Determine optimal search strategy
             strategy = await self.smart_router.route_search(query, user_context)
-            
+
             # Execute search with selected strategy
             results = await self.smart_router.execute_search(
                 query, strategy, limit=limit, filters=filters
             )
-            
+
+            response_time = (datetime.utcnow() - start_time).total_seconds()
+
             # Log search performance
-            logger.info(f"Search completed: {len(results)} results using {strategy}")
-            
+            logger.info(
+                f"Search completed: {len(results)} results using {strategy} in {response_time:.2f}s"
+            )
+
+            # Send analytics
+            if self.analytics:
+                await self.analytics.log_search_execution(
+                    query, strategy, results, response_time
+                )
+
             return results
             
         except Exception as e:

--- a/src/trackrealties/analytics/search.py
+++ b/src/trackrealties/analytics/search.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from enum import Enum
+
+from ..models.search import SearchResult
+
+logger = logging.getLogger(__name__)
+
+
+class InMemoryAnalyticsStore:
+    """Simple in-memory store for analytics data."""
+
+    def __init__(self) -> None:
+        self._search_logs: List[Dict[str, Any]] = []
+
+    async def log_search(self, data: Dict[str, Any]) -> None:
+        self._search_logs.append(data)
+
+    async def get_all_searches(self) -> List[Dict[str, Any]]:
+        return list(self._search_logs)
+
+
+class SearchAnalytics:
+    """Monitors and analyzes search performance."""
+
+    def __init__(self, analytics_store: Optional[InMemoryAnalyticsStore] = None) -> None:
+        self.analytics_store = analytics_store or InMemoryAnalyticsStore()
+
+    async def log_search_execution(
+        self,
+        query: str,
+        strategy: Enum,
+        results: List[SearchResult],
+        response_time: float,
+    ) -> None:
+        """Log search execution for analysis."""
+        analytics_data = {
+            "timestamp": datetime.utcnow(),
+            "query": query,
+            "strategy": strategy.value if isinstance(strategy, Enum) else str(strategy),
+            "result_count": len(results),
+            "response_time": response_time,
+            "has_results": len(results) > 0,
+            "user_feedback": None,  # Placeholder for future use
+        }
+
+        await self.analytics_store.log_search(analytics_data)
+        logger.debug("Logged search analytics: %s", analytics_data)
+
+    async def generate_performance_report(self) -> Dict[str, Any]:
+        """Generate search performance analytics report."""
+        return {
+            "strategy_performance": await self._analyze_strategy_performance(),
+            "query_patterns": await self._analyze_query_patterns(),
+            "failure_analysis": await self._analyze_failed_searches(),
+            "recommendations": await self._generate_optimization_recommendations(),
+        }
+
+    async def _analyze_strategy_performance(self) -> Dict[str, Any]:
+        searches = await self.analytics_store.get_all_searches()
+        performance: Dict[str, Dict[str, Any]] = {}
+        for entry in searches:
+            strategy = entry["strategy"]
+            perf = performance.setdefault(strategy, {"count": 0, "avg_response_time": 0.0})
+            perf["count"] += 1
+        for strategy, perf in performance.items():
+            times = [s["response_time"] for s in searches if s["strategy"] == strategy]
+            perf["avg_response_time"] = sum(times) / len(times) if times else 0.0
+        return performance
+
+    async def _analyze_query_patterns(self) -> Dict[str, Any]:
+        searches = await self.analytics_store.get_all_searches()
+        queries = [s["query"] for s in searches]
+        return {
+            "total_queries": len(queries),
+            "recent_queries": queries[-5:],
+        }
+
+    async def _analyze_failed_searches(self) -> Dict[str, Any]:
+        searches = await self.analytics_store.get_all_searches()
+        failures = [s for s in searches if not s["has_results"]]
+        return {
+            "failed_count": len(failures),
+            "failed_queries": [f["query"] for f in failures][-5:],
+        }
+
+    async def _generate_optimization_recommendations(self) -> Dict[str, Any]:
+        failures = await self._analyze_failed_searches()
+        if failures["failed_count"] > 0:
+            return {
+                "message": "Review failed queries for potential data gaps and tune search thresholds."
+            }
+        return {"message": "Search system performing optimally."}
+
+
+# Shared global instance for application use
+search_analytics = SearchAnalytics()

--- a/src/trackrealties/api/routes/analytics.py
+++ b/src/trackrealties/api/routes/analytics.py
@@ -13,6 +13,7 @@ from sqlalchemy import text
 from ...models.property import PropertyListing
 from ...analytics.cma_engine import ComparativeMarketAnalysis
 from ..dependencies import get_cma_engine, get_db_connection
+from ...analytics.search import search_analytics
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -63,3 +64,9 @@ async def generate_cma_endpoint(
     except Exception as e:
         logger.error(f"Error generating CMA report: {e}")
         raise HTTPException(status_code=500, detail="Internal Server Error")
+
+
+@router.get("/search-report", summary="Get aggregated search analytics")
+async def get_search_report():
+    """Return aggregated search analytics metrics."""
+    return await search_analytics.generate_performance_report()


### PR DESCRIPTION
## Summary
- implement `SearchAnalytics` class and in-memory store
- log analytics in `EnhancedRAGPipeline`
- expose `/analytics/search-report` endpoint
- document usage in **Task 9,md**

## Testing
- `pytest -q` *(fails: invalid DSN and connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fdaf92bac832db1505e66530b7511