### PR TITLE
Remove duplicate RealEstateHallucinationDetector

### DIFF
--- a/src/trackrealties/rag/__init__.py
+++ b/src/trackrealties/rag/__init__.py
@@ -7,7 +7,7 @@ This module provides intelligent search and context-aware responses for real est
 from .search import VectorSearch, GraphSearch, HybridSearchEngine
 from .router import QueryRouter
 from .synthesizer import ResponseSynthesizer
-from .validation import RealEstateHallucinationDetector
+from ..validation import RealEstateHallucinationDetector
 
 __all__ = [
     'VectorSearch',

--- a/src/trackrealties/rag/validation.py
+++ b/src/trackrealties/rag/validation.py
@@ -143,22 +143,3 @@ class ResponseValidator:
 
 
 
-class RealEstateHallucinationDetector:
-    """Simple hallucination detector for real estate content."""
-
-    def __init__(self):
-        self.factual_patterns = {
-            "prices": r"\$[\d,]+",
-        }
-
-    async def detect_hallucinations(
-        self, response: str, search_results: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        issues: List[str] = []
-        for name, pattern in self.factual_patterns.items():
-            for claim in re.findall(pattern, response):
-                if not any(
-                    claim in res.get("content", "") for res in search_results.get("results", [])
-                ):
-                    issues.append(f"Unsupported {name} claim: {claim}")
-        return {"has_hallucinations": bool(issues), "issues": issues}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from src.trackrealties.core.database import db_pool
 
 from src.trackrealties.agents.context import ContextManager
 from src.trackrealties.rag.enhanced_rag_pipeline import TrackRealitiesEnhancedRAG
-from src.trackrealties.rag.validation import RealEstateHallucinationDetector
+from src.trackrealties.validation.hallucination import RealEstateHallucinationDetector
 
 @pytest.fixture(scope="function", autouse=True)
 async def initialize_db_pool(monkeypatch):

--- a/tests/test_real_estate_hallucination_detector.py
+++ b/tests/test_real_estate_hallucination_detector.py
@@ -1,13 +1,11 @@
-import asyncio
 import pytest
-from src.trackrealties.rag.validation import RealEstateHallucinationDetector
+from src.trackrealties.validation.hallucination import RealEstateHallucinationDetector
 
 
 @pytest.mark.asyncio
 async def test_hallucination_detection():
     detector = RealEstateHallucinationDetector()
-    response = "The property sold for $500,000 yesterday."
-    search_results = {"results": [{"content": "The property sold for $400,000 yesterday."}]}
-    result = await detector.detect_hallucinations(response, search_results)
-    assert result["has_hallucinations"] is True
-    assert result["issues"]
+    response = "This property is priced at $250,000,000 and offers an ROI of 150%."
+    result = await detector.validate(response, {})
+    assert not result.is_valid
+    assert result.issues


### PR DESCRIPTION
## Summary
- delete duplicate `RealEstateHallucinationDetector` from `rag/validation.py`
- reference central `RealEstateHallucinationDetector` implementation from `validation` package
- update fixtures and tests to import from unified location
- adapt real estate hallucination test to new validator API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880baa72c28832da616839be96d1ad1